### PR TITLE
explicitly pass event to event handler

### DIFF
--- a/modules/Eventhandler.js
+++ b/modules/Eventhandler.js
@@ -8,19 +8,19 @@ export default function eventhandler(event, instance, trigger) {
         console.log("Event Triggered")
     }
     var elementlang;
-    if(event.srcElement.attributes["xml:lang"]){
-        elementlang = event.srcElement.attributes["xml:lang"].nodeValue;
+    if(event.target.attributes["xml:lang"]){
+        elementlang = event.target.attributes["xml:lang"].nodeValue;
         if(elementlang == 'lat'){
             if(instance.prefs.getdebugstatus()){
                 console.log("Running word as latin, lang taken from element")
             }
-            return processwordlat(event.srcElement, instance);
+            return processwordlat(event.target, instance);
         }
         if(elementlang == 'gre'){
             if(instance.prefs.getdebugstatus()){
                 console.log("Running word as Greek, lang taken from element")
             }
-            return processwordgre(event.srcElement, instance);
+            return processwordgre(event.target, instance);
         }
     } else {
         elementlang = instance.defaultlang;
@@ -28,13 +28,13 @@ export default function eventhandler(event, instance, trigger) {
             if(instance.prefs.getdebugstatus()){
                 console.log("Running word as latin, lang taken from default")
             }
-            return processwordlat(event.srcElement, instance);
+            return processwordlat(event.target, instance);
         }
         if(elementlang == 'gre'){
             if(instance.prefs.getdebugstatus()){
                 console.log("Running word as greek, lang taken from default")
             }
-            return processwordgre(event.srcElement, instance);
+            return processwordgre(event.target, instance);
         }
     }
 }

--- a/modules/morphlib.js
+++ b/modules/morphlib.js
@@ -85,7 +85,7 @@ class morphlib {
                 if(this.prefs.getdebugstatus()){
                     console.log("Adding " + x + "event");
                 }
-                $('body').bind(x, function () {
+                $('body').bind(x, function (event) {
                     eventhandler(event, this, x);
                 });
                 if(this.prefs.getdebugstatus()){
@@ -99,7 +99,7 @@ class morphlib {
                 var bodydebug = $('body');
                 console.log(bodydebug);
             }
-            $('body').on('dblclick', '*', function () {
+            $('body').on('dblclick', '*', function (event) {
                 var tokenobject = eventhandler(event, instance, "click");
                 var morphresponse =morphservice(
                     tokenobject,
@@ -109,7 +109,7 @@ class morphlib {
                     instance.prefs.getmorphserviceversion(instance.currentlang),
                     instance);
             })
-            $('body').on('touch', '*', function () {
+            $('body').on('touch', '*', function (event) {
                 eventhandler(event, instance, "touch");
             })
             if(this.prefs.getdebugstatus()){

--- a/modules/popup.js
+++ b/modules/popup.js
@@ -4,13 +4,14 @@
 import * as main from "./morphlib"
 export default function launchPopup(morpgresponse, instance){
     var debug = instance.prefs.getdebugstatus();
+    var myWindow;
     if(instance.popup){
         instance.popup.close();
-        var myWindow = window.open("", "morplibWindow", "width=600,height=400");
+        myWindow = window.open("", "morplibWindow", "width=600,height=400");
         myWindow.document.open();
         myWindow.focus();
     } else {
-        var myWindow = window.open("", "morplibWindow", "width=600,height=400");
+        myWindow = window.open("", "morplibWindow", "width=600,height=400");
     }
     myWindow.document.write('<head><link rel="stylesheet" href="morphwindow.css" type="text/css" /><title>Morphology Library Window</title> </head>');
     if(!myWindow){


### PR DESCRIPTION
We were previously just assuming we had a global event object in the event handler, but with the jQuery on and bind events, the first argument to an eventhandler function is the jQuery Event object, which wraps the global object in a cross-browser compatible facade. This also means that we should use jQuery.Event.target to get the original DOM element which initiated the event (rather than srcElement).

also  included a fix for the scoping of the myWindow variable on the popup.